### PR TITLE
feat(parser.dart): add new parser for HTML content to Codelab object

### DIFF
--- a/dart/lib/parser.dart
+++ b/dart/lib/parser.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+
+import 'package:html/parser.dart' as html5parser;
+import 'package:html/dom.dart';
+import 'package:intl/intl.dart';
+import 'package:quiver/strings.dart' as quiver_strings;
+import 'package:yaml/yaml.dart';
+import 'models.dart';
+
+const String metadata = "metadata";
+const String duration = "duration";
+const String alterSuccess = "alert-success";
+const String alterInfo = "alert-info";
+const String alterWarning = "alert-warning";
+const String alterDanger = "alert-danger";
+
+/// Check if the given [node] is a metadata
+bool isMetadata(Element node) => node.localName == metadata;
+
+/// Check if the given [node] is a duration
+bool isDuration(Element node) => node.localName == duration;
+
+/// Check if the given [node] is an info success
+bool isAlertSuccess(Element node) => node.localName == alterSuccess;
+
+/// Check if the given [node] is an info alert
+bool isAlertInfo(Element node) => node.localName == alterInfo;
+
+/// Check if the given [node] is a warning alert
+bool isAlertWarning(Element node) => node.localName == alterWarning;
+
+/// Check if the given [node] is a danger alert
+bool isAlertDanger(Element node) => node.localName == alterDanger;
+
+/// Get the define duration (H:mm) form the given [innerHtml] in minutes
+int toMinute(String innerHtml) {
+  final format = DateFormat("H:mm");
+  final datetime = format.parse(innerHtml.trim());
+
+  return datetime.hour * 60 + datetime.minute;
+}
+
+/// Get the define metadata form the given [innerHtml]
+String toMetadata(String innerHtml) => innerHtml.trim();
+
+enum AlertType { success, info, warning, danger }
+
+/// Get the defined alert from a given [innerHtml] and [alertType]
+String toAlert(AlertType alertType, String innerHtml) {
+  String alertClass, title, iconClass;
+
+  switch (alertType) {
+    case AlertType.success:
+      alertClass = "alert-success";
+      title = "Success";
+      iconClass = "oi-check";
+      break;
+    case AlertType.info:
+      alertClass = "alert-primary";
+      title = "Note";
+      iconClass = "oi-info";
+      break;
+    case AlertType.warning:
+      alertClass = "alert-warning";
+      title = "Warning";
+      iconClass = "oi-warning";
+      break;
+    case AlertType.danger:
+      alertClass = "alert-danger";
+      title = "Important";
+      iconClass = "oi-fire";
+      break;
+  }
+
+  return """
+    <div class="alert $alertClass flexbox-it" role="alert">
+      <div><span title="$title" class="oi $iconClass oi-custom"></span></div>
+      <div>$innerHtml</div>
+    </div>
+  """;
+}
+
+///
+/// Valid metadata are the one with the following value
+/// - id [String] (required) (auto-generated) : will be the name of the file without extension
+/// - minutes [String] (required) (auto-generated)
+/// - name [String] (required) (fill by the codelab creator)
+/// - description [String] (required) (fill by the codelab creator)
+/// - emails [array] (optional to restrict the access of the codelabs to users with theses emails)
+///
+/// If the metadata is valid, return the corresponding [map]
+Metadata validateMetadata({
+  required String outputFile,
+  required YamlMap metadata,
+}) {
+  if (quiver_strings.isEmpty(outputFile)) {
+    throw FormatException("No outputfile value found to parse file metadata ");
+  }
+  String asJson = json.encode(metadata.value);
+  return Metadata.fromJson(json.decode(asJson));
+}
+
+/// Parse the given [htmlContent] to a codelab
+Codelab parse(String htmlContent, String outputFileName) {
+  final body = html5parser.parse(htmlContent).body;
+  final h1Element = body?.querySelector("h1");
+  if (h1Element == null) {
+    throw FormatException(
+        "no H1 head find to generate file $outputFileName. You must provide one !");
+  }
+
+  final title = h1Element.innerHtml;
+  final stepSize = body?.querySelectorAll("h2").length;
+
+  int index = 0;
+  Step? currentStep;
+  List<Step?> steps = [];
+  String metadataAsString = "";
+
+  body?.nodes.forEach((node) {
+    if (node is Element) {
+      if (isMetadata(node)) {
+        metadataAsString = toMetadata(node.innerHtml);
+      } else {
+        //
+        // H2 == New Step
+        //
+        if (node.localName == "h2") {
+          index++;
+
+          currentStep = Step(
+            order: index,
+            label: node.innerHtml,
+            isLast: index == stepSize,
+          );
+
+          steps.add(currentStep);
+
+          //
+          // Nodes for the current Step
+          //
+        } else if (currentStep != null) {
+          if (isDuration(node)) {
+            currentStep?.minutes = toMinute(node.innerHtml);
+          } else {
+            // alert success
+            if (isAlertSuccess(node)) {
+              node.innerHtml = toAlert(AlertType.success, node.innerHtml);
+            }
+            // alert info
+            if (isAlertInfo(node)) {
+              node.innerHtml = toAlert(AlertType.info, node.innerHtml);
+            }
+            // alert warning
+            if (isAlertWarning(node)) {
+              node.innerHtml = toAlert(AlertType.warning, node.innerHtml);
+            }
+            // alert danger
+            if (isAlertDanger(node)) {
+              node.innerHtml = toAlert(AlertType.danger, node.innerHtml);
+            }
+
+            //
+            // Populate content of the current step
+            //
+            currentStep?.content.append(node.clone(true));
+          }
+        }
+      }
+    }
+  });
+
+  const initialValue = 0;
+
+  final totalMinutes =
+      steps.fold(initialValue, (curr, next) => curr + (next?.minutes ?? 0));
+
+  final validMetadata = validateMetadata(
+    outputFile: outputFileName,
+    metadata: loadYaml(metadataAsString),
+  );
+  return Codelab(
+    metadata: validMetadata,
+    title: title,
+    steps: steps,
+    minutes: totalMinutes,
+  );
+}

--- a/dart/pubspec.lock
+++ b/dart/pubspec.lock
@@ -162,7 +162,7 @@ packages:
     source: hosted
     version: "3.1.1"
   coverage:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: coverage
       sha256: "8acabb8306b57a409bf4c83522065672ee13179297a6bb0cb9ead73948df7c76"
@@ -602,7 +602,7 @@ packages:
     source: hosted
     version: "1.2.1"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   logging: ^1.2.0
   markdown: ^7.1.1
   quiver: ^3.2.1
+  yaml: ^3.1.2
 
 dev_dependencies:
   build_cli: ^2.2.3
@@ -21,4 +22,5 @@ dev_dependencies:
   pedantic: ^1.11.1
   lints: ^2.1.0
   test: ^1.24.0
+  coverage: ^1.7.2
 

--- a/dart/test/parser_test.dart
+++ b/dart/test/parser_test.dart
@@ -1,0 +1,99 @@
+import 'package:codelabs_builder/models.dart';
+import 'package:test/test.dart';
+import 'package:codelabs_builder/parser.dart';
+import 'package:yaml/yaml.dart'; // Adjust the import path as needed
+
+void main() {
+  group('Utility Functions', () {
+    test('toMinute correctly converts time string to minutes', () {
+      expect(toMinute('1:30'), equals(90));
+      expect(toMinute('0:15'), equals(15));
+    });
+
+    test('validateMetadata returns Metadata for valid input', () {
+      String outputFile = 'test_output';
+      YamlMap validMetadataYaml = loadYaml('''
+        longTitle: "Example Long Title"
+        name: "Example Name"
+        description: "This is an example description."
+        lastModified: "2023-01-01"
+        image: "example_image.png"
+        post: "example_post"
+        googleUA: "UA-12345678-1"
+      ''');
+
+      Metadata result =
+          validateMetadata(outputFile: outputFile, metadata: validMetadataYaml);
+
+      expect(result, isA<Metadata>());
+      expect(result.longTitle, equals("Example Long Title"));
+      expect(result.name, equals("Example Name"));
+      expect(result.description, equals("This is an example description."));
+      expect(result.lastModified, equals("2023-01-01"));
+      expect(result.image, equals("example_image.png"));
+      expect(result.post, equals("example_post"));
+      expect(result.googleUA, equals("UA-12345678-1"));
+      // Validate other properties as needed
+    });
+
+    test('validateMetadata throws FormatException for empty outputFile', () {
+      YamlMap validMetadataYaml = loadYaml('''
+        longTitle: "Example Long Title"
+        name: "Example Name"
+        description: "This is an example description."
+        lastModified: "2023-01-01"
+        image: "example_image.png"
+        post: "example_post"
+        googleUA: "UA-12345678-1"
+      ''');
+
+      expect(
+          () => validateMetadata(outputFile: '', metadata: validMetadataYaml),
+          throwsFormatException);
+    });
+  });
+
+  group('HTML Parsing', () {
+    test('parse successfully parses valid HTML content into Codelab', () {
+      String htmlContent = '''
+<metadata>
+longTitle: "Test Codelab"
+name: "test-codelab"
+description: "A test codelab to demonstrate functionality."
+lastModified: "2023-01-01"
+image: "test_image.png"
+post: "test_post"
+googleUA: "UA-12345678-1"
+</metadata>
+
+<h1 id="introduction-to-test-codelab">Introduction to Test Codelab</h1>
+<p>This is an introductory paragraph for the test codelab.</p>
+<h2 id="step-1-initial-step">Step 1: Initial Step</h2>
+<p>Content for the first step of the test codelab.</p>
+<h2 id="step-2-next-step">Step 2: Next Step</h2>
+<p>Content for the second step of the test codelab.</p>
+    ''';
+
+      String outputFileName = 'test_output';
+      final result = parse(htmlContent, outputFileName);
+
+      expect(result, isA<Codelab>());
+      expect(result.metadata.longTitle, equals("Test Codelab"));
+      expect(result.metadata.name, equals("test-codelab"));
+      expect(result.metadata.description,
+          equals("A test codelab to demonstrate functionality."));
+      expect(result.metadata.lastModified, equals("2023-01-01"));
+      expect(result.metadata.image, equals("test_image.png"));
+      expect(result.metadata.post, equals("test_post"));
+      expect(result.metadata.googleUA, equals("UA-12345678-1"));
+
+      expect(result.title, equals("Introduction to Test Codelab"));
+      expect(result.steps.length, equals(2));
+      expect(result.steps[0]?.label, equals("Step 1: Initial Step"));
+      expect(result.steps[1]?.label, equals("Step 2: Next Step"));
+      // Further detailed checks on the content of steps can be added
+    });
+
+    // Add more tests as needed
+  });
+}


### PR DESCRIPTION
feat(pubspec.yaml): add yaml dependency for parsing yaml metadata
test(parser_test.dart): add unit tests for parser and utility functions
chore: remove unused .keep file in test directory